### PR TITLE
Add support for containerd 2.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,9 +60,15 @@ jobs:
             bin/containerd-guest-pull-grpc
 
   integration-test:
-    name: Integration Test
+    name: Integration Test (containerd ${{ matrix.containerd-version }})
     runs-on: ubuntu-24.04
     needs: [build]
+    strategy:
+      matrix:
+        containerd-version: ['1.7.26', '2.0.3']
+      fail-fast: false
+    env:
+      CONTAINERD_VERSION: ${{ matrix.containerd-version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -49,19 +49,35 @@ sudo ./tests/prepare/enable_guest-pull_service.sh
 
 ### 3. Configure containerd
 
+#### for containerd version 1.7.x
 Update your containerd configuration (`/etc/containerd/config.toml`) to use the guest-pull snapshotter:
 
 ```toml
-[proxy_plugins]
-  [proxy_plugins.guest-pull]
-    type = "snapshot"
-    address = "/run/containerd-guest-pull-grpc/containerd-guest-pull-grpc.sock"
 [plugins."io.containerd.grpc.v1.cri".containerd]
     disable_snapshot_annotations = false
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-qemu-coco-dev]
     snapshotter = "guest-pull"
+[proxy_plugins]
+  [proxy_plugins.guest-pull]
+    type = "snapshot"
+    address = "/run/containerd-guest-pull-grpc/containerd-guest-pull-grpc.sock"
 ```
 
+#### for containerd version 2.0.x
+Update your containerd configuration (`/etc/containerd/config.toml`) to use the guest-pull snapshotter:
+
+```toml
+[plugins."io.containerd.cri.v1.images".runtime_platforms.kata-qemu-coco-dev]
+    snapshotter = "guest-pull"
+[plugins."io.containerd.cri.v1.images"]
+    disable_snapshot_annotations = false
+[plugins."io.containerd.cri.v1.runtime".containerd.runtimes.kata-qemu-coco-dev]
+    snapshotter = "guest-pull"
+[proxy_plugins]
+  [proxy_plugins.guest-pull]
+    type = "snapshot"
+    address = "/run/containerd-guest-pull-grpc/containerd-guest-pull-grpc.sock"
+```
 ### 4. Install Confidential Containers (CoCo)
 
 ```bash
@@ -87,6 +103,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: nginx-kata
+  annotations:
+    io.containerd.cri.runtime-handler: kata-qemu-coco-dev
 spec:
   runtimeClassName: kata-qemu-coco-dev
   containers:

--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,7 @@ const (
 	DefaultLogLevel = log.InfoLevel
 
 	// DefaultRootDir is the default root directory for the snapshotter
-	DefaultRootDir = "/var/lib/containerd-guest-pull-grpc"
+	DefaultRootDir = "/var/lib/containerd/io.containerd.snapshotter.v1.guest-pull"
 
 	// DefaultImageServiceAddress is the default address for the containerd image service
 	DefaultImageServiceAddress = "/run/containerd/containerd.sock"
@@ -64,16 +64,16 @@ func ValidateConfig() error {
 	if *RootDir == "" {
 		return errors.New("root directory must be specified")
 	}
-	
+
 	if err := os.MkdirAll(*RootDir, 0700); err != nil {
 		return errors.Wrapf(err, "failed to create root directory %s", *RootDir)
 	}
-	
+
 	// Test write permissions with a single operation
 	testFile := filepath.Join(*RootDir, ".write_test")
 	if err := os.WriteFile(testFile, []byte{}, 0600); err != nil {
 		return errors.Wrapf(err, "root directory %s is not writable", *RootDir)
 	}
-	
+
 	return os.Remove(testFile)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -13,7 +13,7 @@ func TestDefaultValues(t *testing.T) {
 	assert.Equal(t, "/run/containerd-guest-pull-grpc/containerd-guest-pull-grpc.sock", DefaultAddress)
 	assert.Equal(t, "/etc/containerd-guest-pull-grpc/config.toml", DefaultConfigPath)
 	assert.Equal(t, log.InfoLevel, DefaultLogLevel)
-	assert.Equal(t, "/var/lib/containerd-guest-pull-grpc", DefaultRootDir)
+	assert.Equal(t, "/var/lib/containerd/io.containerd.snapshotter.v1.guest-pull", DefaultRootDir)
 	assert.Equal(t, "/run/containerd/containerd.sock", DefaultImageServiceAddress)
 }
 

--- a/tests/prepare/install_coco.sh
+++ b/tests/prepare/install_coco.sh
@@ -62,4 +62,7 @@ sleep 10
 kubectl get pods -n confidential-containers-system
 kubectl get runtimeclass
 
+echo "Check the containerd config file"
+cat /etc/containerd/config.toml
+
 echo "CoCo installation completed successfully"

--- a/tests/prepare/install_containerd.sh
+++ b/tests/prepare/install_containerd.sh
@@ -34,7 +34,51 @@ containerd config default > /etc/containerd/config.toml
 
 sed -i 's/disabled_plugins = \["cri"\]/enabled_plugins = \["cri"\]/' /etc/containerd/config.toml
 
-sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+# Check the path pattern in the configuration file
+if grep -q "plugins.'io.containerd.cri.v1.runtime'" /etc/containerd/config.toml; then
+    # containerd 2.0+ configuration path
+    OPTIONS_PATH="plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc.options"
+elif grep -q "plugins.\"io.containerd.grpc.v1.cri\"" /etc/containerd/config.toml; then
+    # containerd 1.x configuration path
+    OPTIONS_PATH="plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.runc.options"
+else
+    echo "Cannot recognize the structure of containerd configuration file"
+    exit 1
+fi
+
+# Configure SystemdCgroup setting
+configure_systemd_cgroup() {
+    # If SystemdCgroup = false exists, change it to true
+    if grep -q "SystemdCgroup = false" /etc/containerd/config.toml; then
+        sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+        echo "Changed SystemdCgroup from false to true"
+        return
+    fi
+
+    # In containerd 2.0, the SystemdCgroup setting does not exist in the config file, we need to add it to the correct section
+    if ! grep -q "SystemdCgroup" /etc/containerd/config.toml; then
+        # First find the last line of the options section
+        LAST_OPTION_LINE=$(grep -n "\[$OPTIONS_PATH\]" -A 20 /etc/containerd/config.toml | grep -v "\[$OPTIONS_PATH\]" | grep -m 1 -B 1 "^\s*\[" | head -n 1 | cut -d'-' -f1)
+
+        if [ -n "$LAST_OPTION_LINE" ]; then
+            # Insert SystemdCgroup setting before the last line of the options section
+            sed -i "${LAST_OPTION_LINE}i\\            SystemdCgroup = true" /etc/containerd/config.toml
+            echo "Added SystemdCgroup = true before line ${LAST_OPTION_LINE}"
+        else
+            # If the end of the options section can't be found, try to add after the beginning of the options section
+            OPTIONS_LINE=$(grep -n "\[$OPTIONS_PATH\]" /etc/containerd/config.toml | cut -d':' -f1)
+            if [ -n "$OPTIONS_LINE" ]; then
+                sed -i "${OPTIONS_LINE}a\\            SystemdCgroup = true" /etc/containerd/config.toml
+                echo "Added SystemdCgroup = true after line ${OPTIONS_LINE}"
+            else
+                echo "Cannot find [$OPTIONS_PATH] section, unable to add SystemdCgroup setting"
+                return 1
+            fi
+        fi
+    fi
+}
+
+configure_systemd_cgroup
 
 cat /etc/containerd/config.toml
 

--- a/tests/utils/test_utils.sh
+++ b/tests/utils/test_utils.sh
@@ -148,6 +148,8 @@ verify_image_integrity() {
         return 0
     else
         echo "Guest pull failure: Image $IMAGE_NAME is pulled in the host!"
+        systemctl status guest-pull-snapshotter
+        journalctl -xeu containerd
         return 1
     fi
 }


### PR DESCRIPTION
This commit implements the following changes:
- Add matrix testing for containerd versions 1.7.26 and 2.0.3 in CI workflow
- Update default root directory path to follow containerd snapshotter convention
- Enhance installation scripts to handle different containerd versions
- Add version-specific configuration for containerd 1.x and 2.0+
- Update README.md to update the config both for containerd version 1.7.x and 2.0.x